### PR TITLE
Feat/light rpc

### DIFF
--- a/substrate/bin/node/testing/src/bench.rs
+++ b/substrate/bin/node/testing/src/bench.rs
@@ -385,6 +385,7 @@ impl BenchDb {
 			state_pruning: Some(PruningMode::ArchiveAll),
 			source: database_type.into_settings(dir.into()),
 			blocks_pruning: sc_client_db::BlocksPruning::KeepAll,
+			limit_size: false,
 		};
 		let task_executor = TaskExecutor::new();
 

--- a/substrate/client/cli/src/arg_enums.rs
+++ b/substrate/client/cli/src/arg_enums.rs
@@ -278,6 +278,8 @@ pub enum SyncMode {
 	FastUnsafe,
 	/// Prove finality and download the latest state.
 	Warp,
+	/// minimize startup-time and disk space
+	LightRpc,
 }
 
 impl Into<sc_network::config::SyncMode> for SyncMode {
@@ -293,6 +295,7 @@ impl Into<sc_network::config::SyncMode> for SyncMode {
 				storage_chain_mode: false,
 			},
 			SyncMode::Warp => sc_network::config::SyncMode::Warp,
+			SyncMode::LightRpc => sc_network::config::SyncMode::LightRpc,
 		}
 	}
 }

--- a/substrate/client/cli/src/arg_enums.rs
+++ b/substrate/client/cli/src/arg_enums.rs
@@ -278,7 +278,7 @@ pub enum SyncMode {
 	FastUnsafe,
 	/// Prove finality and download the latest state.
 	Warp,
-	/// minimize startup-time and disk space
+	/// Minimize start-up time and disk space. (RocksDB only)
 	LightRpc,
 }
 

--- a/substrate/client/cli/src/commands/chain_info_cmd.rs
+++ b/substrate/client/cli/src/commands/chain_info_cmd.rs
@@ -19,6 +19,7 @@
 use crate::{CliConfiguration, DatabaseParams, PruningParams, Result as CliResult, SharedParams};
 use codec::{Decode, Encode};
 use sc_client_api::{backend::Backend as BackendT, blockchain::HeaderBackend};
+use sc_network::config::SyncMode;
 use sp_blockchain::Info;
 use sp_runtime::traits::{Block as BlockT, Header as HeaderT};
 use std::{fmt::Debug, io};
@@ -77,6 +78,7 @@ impl ChainInfoCmd {
 			state_pruning: config.state_pruning.clone(),
 			source: config.database.clone(),
 			blocks_pruning: config.blocks_pruning,
+			limit_size: config.network.sync_mode == SyncMode::LightRpc,
 		};
 		let backend = sc_service::new_db_backend::<B>(db_config)?;
 		let info: ChainInfo<B> = backend.blockchain().info().into();

--- a/substrate/client/cli/src/commands/run_cmd.rs
+++ b/substrate/client/cli/src/commands/run_cmd.rs
@@ -362,6 +362,9 @@ impl CliConfiguration for RunCmd {
 	fn role(&self, is_dev: bool) -> Result<Role> {
 		let keyring = self.get_keyring();
 		let is_authority = self.validator || is_dev || keyring.is_some();
+		if self.validator && self.network_params.sync == crate::SyncMode::LightRpc {
+			return Err("Can't run a validator in LightRPC mode.".into());
+		}
 
 		Ok(if is_authority { Role::Authority } else { Role::Full })
 	}

--- a/substrate/client/db/benches/state_access.rs
+++ b/substrate/client/db/benches/state_access.rs
@@ -122,6 +122,7 @@ fn create_backend(config: BenchmarkConfig, temp_dir: &TempDir) -> Backend<Block>
 		state_pruning: Some(PruningMode::ArchiveAll),
 		source: DatabaseSource::ParityDb { path },
 		blocks_pruning: BlocksPruning::KeepAll,
+		limit_size: false,
 	};
 
 	Backend::new(settings, 100).expect("Creates backend")

--- a/substrate/client/network/common/src/sync.rs
+++ b/substrate/client/network/common/src/sync.rs
@@ -34,6 +34,8 @@ pub enum SyncMode {
 	},
 	/// Warp sync - verify authority set transitions and the latest state.
 	Warp,
+	/// minimize startup-time and disk space
+	LightRpc,
 }
 
 impl SyncMode {
@@ -45,6 +47,11 @@ impl SyncMode {
 	/// Returns `true` if `self` is [`Self::LightState`].
 	pub fn light_state(&self) -> bool {
 		matches!(self, Self::LightState { .. })
+	}
+
+	/// Returns `true` if `self` is [`Self::LightRpc`].
+	pub fn light_rpc(&self) -> bool {
+		matches!(self, Self::LightRpc { .. })
 	}
 }
 

--- a/substrate/client/network/test/src/lib.rs
+++ b/substrate/client/network/test/src/lib.rs
@@ -764,8 +764,10 @@ pub trait TestNetFactory: Default + Sized + Send {
 		}
 
 		if !config.force_genesis &&
-			matches!(config.sync_mode, SyncMode::LightState { .. } | SyncMode::Warp)
-		{
+			matches!(
+				config.sync_mode,
+				SyncMode::LightState { .. } | SyncMode::Warp | SyncMode::LightRpc
+			) {
 			test_client_builder = test_client_builder.set_no_genesis();
 		}
 		let backend = test_client_builder.backend();

--- a/substrate/client/service/src/builder.rs
+++ b/substrate/client/service/src/builder.rs
@@ -249,7 +249,7 @@ where
 				wasm_runtime_overrides: config.wasm_runtime_overrides.clone(),
 				no_genesis: matches!(
 					config.network.sync_mode,
-					SyncMode::LightState { .. } | SyncMode::Warp { .. }
+					SyncMode::LightState { .. } | SyncMode::Warp { .. } | SyncMode::LightRpc { .. }
 				),
 				wasm_runtime_substitutes,
 				enable_import_proof_recording,
@@ -813,7 +813,8 @@ where
 		match config.network.sync_mode {
 			SyncMode::LightState { .. } =>
 				return Err("Fast sync doesn't work for archive nodes".into()),
-			SyncMode::Warp => return Err("Warp sync doesn't work for archive nodes".into()),
+			SyncMode::Warp | SyncMode::LightRpc =>
+				return Err("Warp sync doesn't work for archive nodes".into()),
 			SyncMode::Full => {},
 		}
 	}

--- a/substrate/client/service/src/config.rs
+++ b/substrate/client/service/src/config.rs
@@ -244,7 +244,10 @@ impl Configuration {
 	/// Returns true if the genesis state writing will be skipped while initializing the genesis
 	/// block.
 	pub fn no_genesis(&self) -> bool {
-		matches!(self.network.sync_mode, SyncMode::LightState { .. } | SyncMode::Warp { .. })
+		matches!(
+			self.network.sync_mode,
+			SyncMode::LightState { .. } | SyncMode::Warp { .. } | SyncMode::LightRpc { .. }
+		)
 	}
 
 	/// Returns the database config for creating the backend.
@@ -254,6 +257,7 @@ impl Configuration {
 			state_pruning: self.state_pruning.clone(),
 			source: self.database.clone(),
 			blocks_pruning: self.blocks_pruning,
+			limit_size: self.network.sync_mode == SyncMode::LightRpc,
 		}
 	}
 }

--- a/substrate/client/service/test/src/client/mod.rs
+++ b/substrate/client/service/test/src/client/mod.rs
@@ -1486,6 +1486,7 @@ fn doesnt_import_blocks_that_revert_finality() {
 				state_pruning: Some(PruningMode::ArchiveAll),
 				blocks_pruning: BlocksPruning::KeepAll,
 				source: DatabaseSource::RocksDb { path: tmp.path().into(), cache_size: 1024 },
+				limit_size: false,
 			},
 			u64::MAX,
 		)
@@ -1765,6 +1766,7 @@ fn returns_status_for_pruned_blocks() {
 				state_pruning: Some(PruningMode::blocks_pruning(1)),
 				blocks_pruning: BlocksPruning::KeepFinalized,
 				source: DatabaseSource::RocksDb { path: tmp.path().into(), cache_size: 1024 },
+				limit_size: false,
 			},
 			u64::MAX,
 		)


### PR DESCRIPTION
This adds a new sync mode "light-rpc", which is identical to warp sync but with the following changes:
- light-rpc can't be enabled when running as a validator
- light-rpc mode will not download historical blocks
- light-rpc mode will regularly trigger a database compactification when using rocksdb