### PR TITLE
feat: light rpc fixes and headers pruning

### DIFF
--- a/substrate/bin/node/testing/src/bench.rs
+++ b/substrate/bin/node/testing/src/bench.rs
@@ -386,6 +386,7 @@ impl BenchDb {
 			source: database_type.into_settings(dir.into()),
 			blocks_pruning: sc_client_db::BlocksPruning::KeepAll,
 			limit_size: false,
+			recreate_onstart: false
 		};
 		let task_executor = TaskExecutor::new();
 

--- a/substrate/client/cli/src/arg_enums.rs
+++ b/substrate/client/cli/src/arg_enums.rs
@@ -278,7 +278,8 @@ pub enum SyncMode {
 	FastUnsafe,
 	/// Prove finality and download the latest state.
 	Warp,
-	/// Minimize start-up time and disk space. (BETA, RocksDB only)
+	/// Minimize start-up time and disk space. Similar to Warp but downloads only the latest state
+	/// and skips gap syncing. Recreates the db on every startup. (BETA)
 	LightRpc,
 }
 

--- a/substrate/client/cli/src/commands/chain_info_cmd.rs
+++ b/substrate/client/cli/src/commands/chain_info_cmd.rs
@@ -79,6 +79,7 @@ impl ChainInfoCmd {
 			source: config.database.clone(),
 			blocks_pruning: config.blocks_pruning,
 			limit_size: config.network.sync_mode == SyncMode::LightRpc,
+			recreate_onstart: config.network.sync_mode == SyncMode::LightRpc,
 		};
 		let backend = sc_service::new_db_backend::<B>(db_config)?;
 		let info: ChainInfo<B> = backend.blockchain().info().into();

--- a/substrate/client/cli/src/config.rs
+++ b/substrate/client/cli/src/config.rs
@@ -262,7 +262,7 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 	fn blocks_pruning(&self) -> Result<BlocksPruning> {
 		self.pruning_params()
 			.map(|x| x.blocks_pruning())
-			.unwrap_or_else(|| Ok(BlocksPruning::KeepFinalized))
+			.unwrap_or_else(|| Ok(BlocksPruning::KeepFinalized { prune_headers: false }))
 	}
 
 	/// Get the chain ID (string).

--- a/substrate/client/cli/src/params/pruning_params.rs
+++ b/substrate/client/cli/src/params/pruning_params.rs
@@ -64,6 +64,10 @@ pub struct PruningParams {
 		default_value = "archive-canonical"
 	)]
 	pub blocks_pruning: DatabasePruningMode,
+
+	/// Enables the block header pruning.
+	#[arg(long, value_name = "PRUNING_MODE", default_value = "false")]
+	pub prune_block_headers: bool,
 }
 
 impl PruningParams {
@@ -74,7 +78,15 @@ impl PruningParams {
 
 	/// Get the block pruning value from the parameters
 	pub fn blocks_pruning(&self) -> error::Result<BlocksPruning> {
-		Ok(self.blocks_pruning.into())
+		let result = match self.blocks_pruning {
+			DatabasePruningMode::Archive => BlocksPruning::KeepAll,
+			DatabasePruningMode::ArchiveCanonical =>
+				BlocksPruning::KeepFinalized { prune_headers: self.prune_block_headers },
+			DatabasePruningMode::Custom(n) =>
+				BlocksPruning::Some { blocks: n, prune_headers: self.prune_block_headers },
+		};
+
+		Ok(result)
 	}
 }
 
@@ -114,16 +126,6 @@ impl Into<PruningMode> for DatabasePruningMode {
 			DatabasePruningMode::Archive => PruningMode::ArchiveAll,
 			DatabasePruningMode::ArchiveCanonical => PruningMode::ArchiveCanonical,
 			DatabasePruningMode::Custom(n) => PruningMode::blocks_pruning(n),
-		}
-	}
-}
-
-impl Into<BlocksPruning> for DatabasePruningMode {
-	fn into(self) -> BlocksPruning {
-		match self {
-			DatabasePruningMode::Archive => BlocksPruning::KeepAll,
-			DatabasePruningMode::ArchiveCanonical => BlocksPruning::KeepFinalized,
-			DatabasePruningMode::Custom(n) => BlocksPruning::Some(n),
 		}
 	}
 }

--- a/substrate/client/cli/src/runner.rs
+++ b/substrate/client/cli/src/runner.rs
@@ -187,6 +187,10 @@ pub fn print_node_infos<C: SubstrateCli>(config: &Configuration) {
 			.path()
 			.map_or_else(|| "<unknown>".to_owned(), |p| p.display().to_string())
 	);
+
+	if config.network.sync_mode.light_rpc() {
+		info!("⚡  Light-RPC mode enabled");
+	}
 }
 
 #[cfg(test)]

--- a/substrate/client/db/benches/state_access.rs
+++ b/substrate/client/db/benches/state_access.rs
@@ -123,6 +123,7 @@ fn create_backend(config: BenchmarkConfig, temp_dir: &TempDir) -> Backend<Block>
 		source: DatabaseSource::ParityDb { path },
 		blocks_pruning: BlocksPruning::KeepAll,
 		limit_size: false,
+		recreate_onstart: true
 	};
 
 	Backend::new(settings, 100).expect("Creates backend")

--- a/substrate/client/db/src/lib.rs
+++ b/substrate/client/db/src/lib.rs
@@ -42,7 +42,7 @@ mod upgrade;
 mod utils;
 
 use linked_hash_map::LinkedHashMap;
-use log::{debug, trace, warn};
+use log::{debug, trace, info, warn};
 use parking_lot::{Mutex, RwLock};
 use std::{
 	collections::{HashMap, HashSet},
@@ -63,7 +63,7 @@ use sc_client_api::{
 	backend::NewBlockState,
 	leaves::{FinalizationOutcome, LeafSet},
 	utils::is_descendent_of,
-	IoInfo, MemoryInfo, MemorySize, UsageInfo,
+	Backend as ClientApiBackend, IoInfo, MemoryInfo, MemorySize, UsageInfo,
 };
 use sc_state_db::{IsPruned, LastCanonicalized, StateDb};
 use sp_arithmetic::traits::Saturating;
@@ -320,17 +320,34 @@ pub enum BlocksPruning {
 	/// Keep full block history, of every block that was ever imported.
 	KeepAll,
 	/// Keep full finalized block history.
-	KeepFinalized,
+	KeepFinalized {
+		/// Prune block headers of the displaced branches.
+		prune_headers: bool,
+	},
 	/// Keep N recent finalized blocks.
-	Some(u32),
+	Some {
+		/// Block number.
+		blocks: u32,
+		/// Prune block headers as well.
+		prune_headers: bool,
+	},
 }
 
 impl BlocksPruning {
 	/// True if this is an archive pruning mode (either KeepAll or KeepFinalized).
 	pub fn is_archive(&self) -> bool {
 		match *self {
-			BlocksPruning::KeepAll | BlocksPruning::KeepFinalized => true,
-			BlocksPruning::Some(_) => false,
+			BlocksPruning::KeepAll | BlocksPruning::KeepFinalized { .. } => true,
+			BlocksPruning::Some { .. } => false,
+		}
+	}
+
+	/// True if the block header pruning is enabled.
+	pub fn prune_headers(&self) -> bool {
+		match *self {
+			BlocksPruning::KeepAll => false,
+			BlocksPruning::KeepFinalized { prune_headers } => prune_headers,
+			BlocksPruning::Some { prune_headers, .. } => prune_headers,
 		}
 	}
 }
@@ -667,6 +684,19 @@ impl<Block: BlockT> BlockchainDb<Block> {
 			}
 		}
 		Ok(None)
+	}
+
+	fn prune_block_header(
+		&self,
+		transaction: &mut Transaction<DbHash>,
+		hash: Block::Hash,
+	) -> ClientResult<()> {
+		debug!(target: "blockchain", "Removing block header #{}", hash);
+
+		// Removes block header from the local cache as well
+		self.remove_header_metadata(hash);
+
+		utils::remove_header(transaction, &*self.db, BlockId::<Block>::Hash(hash))
 	}
 }
 
@@ -1162,7 +1192,10 @@ impl<Block: BlockT> Backend<Block> {
 	/// Create new memory-backed client backend for tests.
 	#[cfg(any(test, feature = "test-helpers"))]
 	pub fn new_test(blocks_pruning: u32, canonicalization_delay: u64) -> Self {
-		Self::new_test_with_tx_storage(BlocksPruning::Some(blocks_pruning), canonicalization_delay)
+		Self::new_test_with_tx_storage(
+			BlocksPruning::Some { blocks: blocks_pruning, prune_headers: false },
+			canonicalization_delay,
+		)
 	}
 
 	/// Create new memory-backed client backend for tests.
@@ -1175,8 +1208,8 @@ impl<Block: BlockT> Backend<Block> {
 		let db = sp_database::as_database(db);
 		let state_pruning = match blocks_pruning {
 			BlocksPruning::KeepAll => PruningMode::ArchiveAll,
-			BlocksPruning::KeepFinalized => PruningMode::ArchiveCanonical,
-			BlocksPruning::Some(n) => PruningMode::blocks_pruning(n),
+			BlocksPruning::KeepFinalized { .. } => PruningMode::ArchiveCanonical,
+			BlocksPruning::Some { blocks: n, .. } => PruningMode::blocks_pruning(n),
 		};
 		let db_setting = DatabaseSettings {
 			trie_cache_maximum_size: Some(16 * 1024 * 1024),
@@ -1379,13 +1412,13 @@ impl<Block: BlockT> Backend<Block> {
 		justification: Option<Justification>,
 		current_transaction_justifications: &mut HashMap<Block::Hash, Justification>,
 		remove_displaced: bool,
-	) -> ClientResult<MetaUpdate<Block>> {
+	) -> ClientResult<(MetaUpdate<Block>, Vec<Block::Hash>)> {
 		// TODO: ensure best chain contains this block.
 		let number = *header.number();
 		self.ensure_sequential_finalization(header, last_finalized)?;
 		let with_state = sc_client_api::Backend::have_state_at(self, hash, number);
 
-		self.note_finalized(
+		let pruned_block_headers = self.note_finalized(
 			transaction,
 			header,
 			hash,
@@ -1402,7 +1435,7 @@ impl<Block: BlockT> Backend<Block> {
 			);
 			current_transaction_justifications.insert(hash, justification);
 		}
-		Ok(MetaUpdate { hash, number, is_best: false, is_finalized: true, with_state })
+		Ok((MetaUpdate { hash, number, is_best: false, is_finalized: true, with_state }, pruned_block_headers))
 	}
 
 	// performs forced canonicalization with a delay after importing a non-finalized block.
@@ -1461,6 +1494,8 @@ impl<Block: BlockT> Backend<Block> {
 		operation.apply_aux(&mut transaction);
 		operation.apply_offchain(&mut transaction);
 
+		let mut pruned_block_headers = Vec::new();
+
 		let mut meta_updates = Vec::with_capacity(operation.finalized_blocks.len());
 		let (best_num, mut last_finalized_hash, mut last_finalized_num, mut block_gap) = {
 			let meta = self.blockchain.meta.read();
@@ -1472,7 +1507,7 @@ impl<Block: BlockT> Backend<Block> {
 		let mut finalized_blocks = operation.finalized_blocks.into_iter().peekable();
 		while let Some((block_hash, justification)) = finalized_blocks.next() {
 			let block_header = self.blockchain.expect_header(block_hash)?;
-			meta_updates.push(self.finalize_block_with_transaction(
+			let (meta_update, pruned_block_headers_part) = self.finalize_block_with_transaction(
 				&mut transaction,
 				block_hash,
 				&block_header,
@@ -1480,7 +1515,11 @@ impl<Block: BlockT> Backend<Block> {
 				justification,
 				&mut current_transaction_justifications,
 				finalized_blocks.peek().is_none(),
-			)?);
+			)?;
+
+			pruned_block_headers.extend_from_slice(&pruned_block_headers_part);
+			meta_updates.push(meta_update);
+
 			last_finalized_hash = block_hash;
 			last_finalized_num = *block_header.number();
 		}
@@ -1653,7 +1692,7 @@ impl<Block: BlockT> Backend<Block> {
 				// TODO: ensure best chain contains this block.
 				self.ensure_sequential_finalization(header, Some(last_finalized_hash))?;
 				let mut current_transaction_justifications = HashMap::new();
-				self.note_finalized(
+				let pruned_block_headers_part =  self.note_finalized(
 					&mut transaction,
 					header,
 					hash,
@@ -1661,6 +1700,7 @@ impl<Block: BlockT> Backend<Block> {
 					&mut current_transaction_justifications,
 					true,
 				)?;
+				pruned_block_headers.extend_from_slice(&pruned_block_headers_part);
 			} else {
 				// canonicalize blocks which are old enough, regardless of finality.
 				self.force_delayed_canonicalize(&mut transaction)?
@@ -1708,7 +1748,7 @@ impl<Block: BlockT> Backend<Block> {
 					if start > end {
 						transaction.remove(columns::META, meta_keys::BLOCK_GAP);
 						block_gap = None;
-						debug!(target: "db", "Removed block gap.");
+						info!(target: "db", "Removed block gap.");
 					} else {
 						block_gap = Some((start, end));
 						debug!(target: "db", "Update block gap. {:?}", block_gap);
@@ -1725,7 +1765,7 @@ impl<Block: BlockT> Backend<Block> {
 					let gap = (best_num + One::one(), number - One::one());
 					transaction.set(columns::META, meta_keys::BLOCK_GAP, &gap.encode());
 					block_gap = Some(gap);
-					debug!(target: "db", "Detected block gap {:?}", block_gap);
+					info!(target: "db", "Detected block gap {:?}", block_gap);
 				}
 			}
 
@@ -1764,6 +1804,10 @@ impl<Block: BlockT> Backend<Block> {
 				)))
 			}
 		}
+		// Clear block headers pruned by the last block finalization.
+		for hash in pruned_block_headers.into_iter() {
+			self.blockchain().prune_block_header(&mut transaction, hash)?;
+		}
 
 		self.storage.db.commit(transaction)?;
 
@@ -1789,6 +1833,7 @@ impl<Block: BlockT> Backend<Block> {
 	// blocks. Fails if called with a block which was not a child of the last finalized block.
 	/// `remove_displaced` can be set to `false` if this is not the last of many subsequent calls
 	/// for performance reasons.
+	/// Returns a list of hashes of the pruned block headers (can be empty).
 	fn note_finalized(
 		&self,
 		transaction: &mut Transaction<DbHash>,
@@ -1797,7 +1842,8 @@ impl<Block: BlockT> Backend<Block> {
 		with_state: bool,
 		current_transaction_justifications: &mut HashMap<Block::Hash, Justification>,
 		remove_displaced: bool,
-	) -> ClientResult<()> {
+	) -> ClientResult<Vec<Block::Hash>> {
+		let mut pruned_block_headers = Vec::new();
 		let f_num = *f_header.number();
 
 		let lookup_key = utils::number_and_hash_to_lookup_key(f_num, f_hash)?;
@@ -1829,13 +1875,22 @@ impl<Block: BlockT> Backend<Block> {
 			));
 
 			if !matches!(self.blocks_pruning, BlocksPruning::KeepAll) {
-				self.prune_displaced_branches(transaction, &new_displaced)?;
+				let pruned_block_headers_part1 = self.prune_displaced_branches(
+					transaction,
+					&new_displaced,
+					self.blocks_pruning.prune_headers(),
+				)?;
+
+				pruned_block_headers.extend_from_slice(&pruned_block_headers_part1);
 			}
 		}
 
-		self.prune_blocks(transaction, f_num, current_transaction_justifications)?;
+		let pruned_block_headers_part2 =
+			self.prune_blocks(transaction, f_num, current_transaction_justifications)?;
 
-		Ok(())
+		pruned_block_headers.extend_from_slice(&pruned_block_headers_part2);
+
+		Ok(pruned_block_headers)
 	}
 
 	fn prune_blocks(
@@ -1843,10 +1898,12 @@ impl<Block: BlockT> Backend<Block> {
 		transaction: &mut Transaction<DbHash>,
 		finalized_number: NumberFor<Block>,
 		current_transaction_justifications: &mut HashMap<Block::Hash, Justification>,
-	) -> ClientResult<()> {
-		if let BlocksPruning::Some(blocks_pruning) = self.blocks_pruning {
+	) -> ClientResult<Vec<Block::Hash>> {
+		let mut pruned_block_headers = Vec::new();
+
+		if let BlocksPruning::Some { blocks, prune_headers } = self.blocks_pruning {
 			// Always keep the last finalized block
-			let keep = std::cmp::max(blocks_pruning, 1);
+			let keep = std::cmp::max(blocks, 1);
 			if finalized_number >= keep.into() {
 				let number = finalized_number.saturating_sub(keep.into());
 
@@ -1861,25 +1918,36 @@ impl<Block: BlockT> Backend<Block> {
 					} else {
 						self.blockchain.insert_persisted_justifications_if_pinned(hash)?;
 					}
+
+					if prune_headers {
+						pruned_block_headers.push(hash);
+					}
 				};
 
 				self.prune_block(transaction, BlockId::<Block>::number(number))?;
 			}
 		}
-		Ok(())
+		Ok(pruned_block_headers)
 	}
 
 	fn prune_displaced_branches(
 		&self,
 		transaction: &mut Transaction<DbHash>,
 		displaced: &DisplacedLeavesAfterFinalization<Block>,
-	) -> ClientResult<()> {
+		prune_headers: bool,
+	) -> ClientResult<Vec<Block::Hash>> {
+		let mut pruned_block_headers = Vec::new();
+
 		// Discard all blocks from displaced branches
 		for &hash in displaced.displaced_blocks.iter() {
 			self.blockchain.insert_persisted_body_if_pinned(hash)?;
 			self.prune_block(transaction, BlockId::<Block>::hash(hash))?;
+
+			if prune_headers {
+				pruned_block_headers.push(hash);
+			}
 		}
-		Ok(())
+		Ok(pruned_block_headers)
 	}
 
 	fn prune_block(
@@ -2118,7 +2186,7 @@ impl<Block: BlockT> sc_client_api::backend::Backend<Block> for Backend<Block> {
 		let header = self.blockchain.expect_header(hash)?;
 
 		let mut current_transaction_justifications = HashMap::new();
-		let m = self.finalize_block_with_transaction(
+		let (m, pruned_block_headers)  = self.finalize_block_with_transaction(
 			&mut transaction,
 			hash,
 			&header,
@@ -2127,6 +2195,11 @@ impl<Block: BlockT> sc_client_api::backend::Backend<Block> for Backend<Block> {
 			&mut current_transaction_justifications,
 			true,
 		)?;
+
+		// Prune block headers after the block finalization if any.
+		for pruned_block_header in pruned_block_headers.into_iter() {
+			self.blockchain().prune_block_header(&mut transaction, pruned_block_header)?;
+		}
 
 		self.storage.db.commit(transaction)?;
 		self.blockchain.update_meta(m);
@@ -2729,7 +2802,7 @@ pub(crate) mod tests {
 				trie_cache_maximum_size: Some(16 * 1024 * 1024),
 				state_pruning: Some(PruningMode::blocks_pruning(1)),
 				source: DatabaseSource::Custom { db: backing, require_create_flag: false },
-				blocks_pruning: BlocksPruning::KeepFinalized,
+				blocks_pruning: BlocksPruning::KeepFinalized { prune_headers: false },
 				limit_size: false,
 			},
 			0,
@@ -3666,8 +3739,11 @@ pub(crate) mod tests {
 
 	#[test]
 	fn prune_blocks_on_finalize() {
-		let pruning_modes =
-			vec![BlocksPruning::Some(2), BlocksPruning::KeepFinalized, BlocksPruning::KeepAll];
+		let pruning_modes = vec![
+			BlocksPruning::Some { blocks: 2, prune_headers: false },
+			BlocksPruning::KeepFinalized { prune_headers: false },
+			BlocksPruning::KeepAll,
+		];
 
 		for pruning_mode in pruning_modes {
 			let backend = Backend::<Block>::new_test_with_tx_storage(pruning_mode, 0);
@@ -3698,7 +3774,7 @@ pub(crate) mod tests {
 			}
 			let bc = backend.blockchain();
 
-			if matches!(pruning_mode, BlocksPruning::Some(_)) {
+			if matches!(pruning_mode, BlocksPruning::Some { .. }) {
 				assert_eq!(None, bc.body(blocks[0]).unwrap());
 				assert_eq!(None, bc.body(blocks[1]).unwrap());
 				assert_eq!(None, bc.body(blocks[2]).unwrap());
@@ -3716,8 +3792,11 @@ pub(crate) mod tests {
 	fn prune_blocks_on_finalize_with_fork() {
 		sp_tracing::try_init_simple();
 
-		let pruning_modes =
-			vec![BlocksPruning::Some(2), BlocksPruning::KeepFinalized, BlocksPruning::KeepAll];
+		let pruning_modes = vec![
+			BlocksPruning::Some { blocks: 2, prune_headers: false },
+			BlocksPruning::KeepFinalized { prune_headers: false },
+			BlocksPruning::KeepAll,
+		];
 
 		for pruning in pruning_modes {
 			let backend = Backend::<Block>::new_test_with_tx_storage(pruning, 10);
@@ -3767,7 +3846,7 @@ pub(crate) mod tests {
 				backend.commit_operation(op).unwrap();
 			}
 
-			if matches!(pruning, BlocksPruning::Some(_)) {
+			if matches!(pruning, BlocksPruning::Some { ..}) {
 				assert_eq!(None, bc.body(blocks[0]).unwrap());
 				assert_eq!(None, bc.body(blocks[1]).unwrap());
 				assert_eq!(None, bc.body(blocks[2]).unwrap());
@@ -3799,7 +3878,10 @@ pub(crate) mod tests {
 		//	\ - 1a - 2a - 3a
 		//	     \ - 2b
 
-		let backend = Backend::<Block>::new_test_with_tx_storage(BlocksPruning::Some(10), 10);
+		let backend = Backend::<Block>::new_test_with_tx_storage(
+			BlocksPruning::Some { blocks: 10, prune_headers: false },
+			10,
+		);
 
 		let make_block = |index, parent, val: u64| {
 			insert_block(&backend, index, parent, None, H256::random(), vec![val.into()], None)
@@ -3839,7 +3921,10 @@ pub(crate) mod tests {
 
 	#[test]
 	fn indexed_data_block_body() {
-		let backend = Backend::<Block>::new_test_with_tx_storage(BlocksPruning::Some(1), 10);
+		let backend = Backend::<Block>::new_test_with_tx_storage(
+			BlocksPruning::Some { blocks: 1, prune_headers: false },
+			10,
+		);
 
 		let x0 = ExtrinsicWrapper::from(0u64).encode();
 		let x1 = ExtrinsicWrapper::from(1u64).encode();
@@ -3883,7 +3968,10 @@ pub(crate) mod tests {
 
 	#[test]
 	fn index_invalid_size() {
-		let backend = Backend::<Block>::new_test_with_tx_storage(BlocksPruning::Some(1), 10);
+		let backend = Backend::<Block>::new_test_with_tx_storage(
+			BlocksPruning::Some { blocks: 1, prune_headers: false },
+			10,
+		);
 
 		let x0 = ExtrinsicWrapper::from(0u64).encode();
 		let x1 = ExtrinsicWrapper::from(1u64).encode();
@@ -3918,7 +4006,10 @@ pub(crate) mod tests {
 
 	#[test]
 	fn renew_transaction_storage() {
-		let backend = Backend::<Block>::new_test_with_tx_storage(BlocksPruning::Some(2), 10);
+		let backend = Backend::<Block>::new_test_with_tx_storage(
+			BlocksPruning::Some { blocks: 2, prune_headers: false },
+			10,
+		);
 		let mut blocks = Vec::new();
 		let mut prev_hash = Default::default();
 		let x1 = ExtrinsicWrapper::from(0u64).encode();
@@ -3965,7 +4056,10 @@ pub(crate) mod tests {
 
 	#[test]
 	fn remove_leaf_block_works() {
-		let backend = Backend::<Block>::new_test_with_tx_storage(BlocksPruning::Some(2), 10);
+		let backend = Backend::<Block>::new_test_with_tx_storage(
+			BlocksPruning::Some { blocks: 2, prune_headers: false },
+			10,
+		);
 		let mut blocks = Vec::new();
 		let mut prev_hash = Default::default();
 		for i in 0..2 {
@@ -4217,7 +4311,8 @@ pub(crate) mod tests {
 
 	#[test]
 	fn revert_finalized_blocks() {
-		let pruning_modes = [BlocksPruning::Some(10), BlocksPruning::KeepAll];
+		let pruning_modes =
+			[BlocksPruning::Some { blocks: 10, prune_headers: false }, BlocksPruning::KeepAll];
 
 		// we will create a chain with 11 blocks, finalize block #8 and then
 		// attempt to revert 5 blocks.
@@ -4239,7 +4334,7 @@ pub(crate) mod tests {
 			match pruning_mode {
 				// we can only revert to blocks for which we have state, if pruning is enabled
 				// then the last state available will be that of the latest finalized block
-				BlocksPruning::Some(_) =>
+				BlocksPruning::Some { .. } =>
 					assert_eq!(backend.blockchain().info().finalized_number, 8),
 				// otherwise if we're not doing state pruning we can revert past finalized blocks
 				_ => assert_eq!(backend.blockchain().info().finalized_number, 5),
@@ -4265,8 +4360,11 @@ pub(crate) mod tests {
 
 	#[test]
 	fn force_delayed_canonicalize_waiting_for_blocks_to_be_finalized() {
-		let pruning_modes =
-			[BlocksPruning::Some(10), BlocksPruning::KeepAll, BlocksPruning::KeepFinalized];
+		let pruning_modes = [
+			BlocksPruning::Some { blocks: 10, prune_headers: false },
+			BlocksPruning::KeepAll,
+			BlocksPruning::KeepFinalized { prune_headers: false },
+		];
 
 		for pruning_mode in pruning_modes {
 			eprintln!("Running with pruning mode: {:?}", pruning_mode);
@@ -4320,7 +4418,7 @@ pub(crate) mod tests {
 				header.hash()
 			};
 
-			if matches!(pruning_mode, BlocksPruning::Some(_)) {
+			if matches!(pruning_mode, BlocksPruning::Some { .. }) {
 				assert_eq!(
 					LastCanonicalized::Block(0),
 					backend.storage.state_db.last_canonicalized()
@@ -4365,7 +4463,7 @@ pub(crate) mod tests {
 				header.hash()
 			};
 
-			if matches!(pruning_mode, BlocksPruning::Some(_)) {
+			if matches!(pruning_mode, BlocksPruning::Some { ..}) {
 				assert_eq!(
 					LastCanonicalized::Block(0),
 					backend.storage.state_db.last_canonicalized()
@@ -4447,7 +4545,7 @@ pub(crate) mod tests {
 				header.hash()
 			};
 
-			if matches!(pruning_mode, BlocksPruning::Some(_)) {
+			if matches!(pruning_mode, BlocksPruning::Some { .. }) {
 				assert_eq!(
 					LastCanonicalized::Block(2),
 					backend.storage.state_db.last_canonicalized()
@@ -4463,7 +4561,10 @@ pub(crate) mod tests {
 
 	#[test]
 	fn test_pinned_blocks_on_finalize() {
-		let backend = Backend::<Block>::new_test_with_tx_storage(BlocksPruning::Some(1), 10);
+		let backend = Backend::<Block>::new_test_with_tx_storage(
+			BlocksPruning::Some { blocks: 1, prune_headers: false },
+			10,
+		);
 		let mut blocks = Vec::new();
 		let mut prev_hash = Default::default();
 
@@ -4624,7 +4725,10 @@ pub(crate) mod tests {
 
 	#[test]
 	fn test_pinned_blocks_on_finalize_with_fork() {
-		let backend = Backend::<Block>::new_test_with_tx_storage(BlocksPruning::Some(1), 10);
+		let backend = Backend::<Block>::new_test_with_tx_storage(
+			BlocksPruning::Some { blocks: 1, prune_headers: false },
+			10,
+		);
 		let mut blocks = Vec::new();
 		let mut prev_hash = Default::default();
 

--- a/substrate/client/db/src/lib.rs
+++ b/substrate/client/db/src/lib.rs
@@ -312,6 +312,8 @@ pub struct DatabaseSettings {
 	pub blocks_pruning: BlocksPruning,
 	/// Try to compactify DB regularly
 	pub limit_size: bool,
+	/// Always recreates DB on startup
+	pub recreate_onstart: bool,
 }
 
 /// Block pruning settings.
@@ -1164,14 +1166,16 @@ impl<Block: BlockT> Backend<Block> {
 			db_source,
 			DatabaseType::Full,
 			false,
+			db_config.recreate_onstart,
 			db_config.limit_size,
 		) {
-			Ok(db) => (false, db),
+			Ok(db) => (db_config.recreate_onstart, db),
 			Err(OpenDbError::DoesNotExist) => {
 				let db = crate::utils::open_database::<Block>(
 					db_source,
 					DatabaseType::Full,
 					true,
+					db_config.recreate_onstart,
 					db_config.limit_size,
 				)?;
 				(true, db)
@@ -1217,6 +1221,7 @@ impl<Block: BlockT> Backend<Block> {
 			source: DatabaseSource::Custom { db, require_create_flag: true },
 			blocks_pruning,
 			limit_size: false,
+			recreate_onstart: false,
 		};
 
 		Self::new(db_setting, canonicalization_delay).expect("failed to create test-db")
@@ -2804,6 +2809,7 @@ pub(crate) mod tests {
 				source: DatabaseSource::Custom { db: backing, require_create_flag: false },
 				blocks_pruning: BlocksPruning::KeepFinalized { prune_headers: false },
 				limit_size: false,
+				recreate_onstart: false,
 			},
 			0,
 		)

--- a/substrate/client/db/src/lib.rs
+++ b/substrate/client/db/src/lib.rs
@@ -339,7 +339,8 @@ impl BlocksPruning {
 	/// True if this is an archive pruning mode (either KeepAll or KeepFinalized).
 	pub fn is_archive(&self) -> bool {
 		match *self {
-			BlocksPruning::KeepAll | BlocksPruning::KeepFinalized { .. } => true,
+			BlocksPruning::KeepAll => true,
+			BlocksPruning::KeepFinalized { prune_headers, .. } => !prune_headers,
 			BlocksPruning::Some { .. } => false,
 		}
 	}
@@ -1753,7 +1754,7 @@ impl<Block: BlockT> Backend<Block> {
 					if start > end {
 						transaction.remove(columns::META, meta_keys::BLOCK_GAP);
 						block_gap = None;
-						info!(target: "db", "Removed block gap.");
+						debug!(target: "db", "Removed block gap.");
 					} else {
 						block_gap = Some((start, end));
 						debug!(target: "db", "Update block gap. {:?}", block_gap);

--- a/substrate/client/db/src/utils.rs
+++ b/substrate/client/db/src/utils.rs
@@ -23,7 +23,7 @@ use std::{fmt, fs, io, path::Path, sync::Arc};
 
 use log::{debug, info};
 
-use crate::{Database, DatabaseSource, DbHash};
+use crate::{columns, Database, DatabaseSource, DbHash};
 use codec::Decode;
 use sp_database::Transaction;
 use sp_runtime::{
@@ -474,6 +474,15 @@ pub fn read_header<Block: BlockT>(
 	}
 }
 
+/// Drop a header from the database.
+pub fn remove_header<Block: BlockT>(
+	transaction: &mut Transaction<DbHash>,
+	db: &dyn Database<DbHash>,
+	id: BlockId<Block>,
+) -> sp_blockchain::Result<()> {
+	remove_from_db(transaction, db, columns::KEY_LOOKUP, columns::HEADER, id)
+}
+
 /// Read meta from the database.
 pub fn read_meta<Block>(
 	db: &dyn Database<DbHash>,
@@ -527,7 +536,7 @@ where
 	let block_gap = db
 		.get(COLUMN_META, meta_keys::BLOCK_GAP)
 		.and_then(|d| Decode::decode(&mut d.as_slice()).ok());
-	debug!(target: "db", "block_gap={:?}", block_gap);
+	info!(target: "db", "block_gap={:?}", block_gap);
 
 	Ok(Meta {
 		best_hash,

--- a/substrate/client/db/src/utils.rs
+++ b/substrate/client/db/src/utils.rs
@@ -359,9 +359,10 @@ fn open_kvdb_rocksdb<Block: BlockT>(
 		},
 	}
 	db_config.memory_budget = memory_budget;
-	// if limit_size {
-	// 	db_config.max_total_wal_size = Some(64 * 1024 * 1024);
-	// }
+	if limit_size {
+		db_config.max_total_wal_size = Some(64 * 1024 * 1024);
+		db_config.max_open_files = 256;
+	}
 
 	if recreate_onstart {
 		log::warn!("Deleting all db files and recreating a new RocksDB database on startup.");

--- a/substrate/client/db/src/utils.rs
+++ b/substrate/client/db/src/utils.rs
@@ -298,7 +298,7 @@ fn open_parity_db<Block: BlockT>(path: &Path, db_type: DatabaseType, create: boo
 
 	let mut create_param = create;
 	if recreate_onstart {
-		log::warn!("Deleting all db files and recreating a new ParityDB database on startup.");
+		log::warn!("Deleting old db files and recreating a new ParityDB database on startup.");
 		drop_database(path)?;
 		create_param = true;
 	}
@@ -365,7 +365,7 @@ fn open_kvdb_rocksdb<Block: BlockT>(
 	}
 
 	if recreate_onstart {
-		log::warn!("Deleting all db files and recreating a new RocksDB database on startup.");
+		log::warn!("Deleting old db files and recreating a new RocksDB database on startup.");
 		drop_database(path)?;
 		db_config.create_if_missing = true;
 	}

--- a/substrate/client/db/src/utils.rs
+++ b/substrate/client/db/src/utils.rs
@@ -171,11 +171,20 @@ where
 	})
 }
 
+/// Drop all db files for the given database source.
+pub fn drop_database(path: &Path) -> Result<(), io::Error> {
+	if path.is_dir() {
+		std::fs::remove_dir_all(path)?;
+	}
+	Ok(())
+}
+
 /// Opens the configured database.
 pub fn open_database<Block: BlockT>(
 	db_source: &DatabaseSource,
 	db_type: DatabaseType,
 	create: bool,
+	recreate_onstart: bool,
 	limit_size: bool,
 ) -> OpenDbResult {
 	// Maybe migrate (copy) the database to a type specific subdirectory to make it
@@ -183,20 +192,21 @@ pub fn open_database<Block: BlockT>(
 	// NOTE: This function can be removed in a few releases
 	maybe_migrate_to_type_subdir::<Block>(db_source, db_type, limit_size)?;
 
-	open_database_at::<Block>(db_source, db_type, create, limit_size)
+	open_database_at::<Block>(db_source, db_type, create, recreate_onstart, limit_size)
 }
 
 fn open_database_at<Block: BlockT>(
 	db_source: &DatabaseSource,
 	db_type: DatabaseType,
 	create: bool,
+	recreate_onstart: bool,
 	limit_size: bool,
 ) -> OpenDbResult {
 	let db: Arc<dyn Database<DbHash>> = match &db_source {
-		DatabaseSource::ParityDb { path } => open_parity_db::<Block>(path, db_type, create)?,
+		DatabaseSource::ParityDb { path } => open_parity_db::<Block>(path, db_type, create, recreate_onstart)?,
 		#[cfg(feature = "rocksdb")]
 		DatabaseSource::RocksDb { path, cache_size } =>
-			open_kvdb_rocksdb::<Block>(path, db_type, create, *cache_size, limit_size)?,
+			open_kvdb_rocksdb::<Block>(path, db_type, create, recreate_onstart, *cache_size, limit_size)?,
 		DatabaseSource::Custom { db, require_create_flag } => {
 			if *require_create_flag && !create {
 				return Err(OpenDbError::DoesNotExist)
@@ -205,11 +215,11 @@ fn open_database_at<Block: BlockT>(
 		},
 		DatabaseSource::Auto { paritydb_path, rocksdb_path, cache_size } => {
 			// check if rocksdb exists first, if not, open paritydb
-			match open_kvdb_rocksdb::<Block>(rocksdb_path, db_type, false, *cache_size, limit_size)
+			match open_kvdb_rocksdb::<Block>(rocksdb_path, db_type, false, false, *cache_size, limit_size)
 			{
 				Ok(db) => db,
 				Err(OpenDbError::NotEnabled(_)) | Err(OpenDbError::DoesNotExist) =>
-					open_parity_db::<Block>(paritydb_path, db_type, create)?,
+					open_parity_db::<Block>(paritydb_path, db_type, create, recreate_onstart)?,
 				Err(as_is) => return Err(as_is),
 			}
 		},
@@ -284,8 +294,16 @@ impl From<io::Error> for OpenDbError {
 	}
 }
 
-fn open_parity_db<Block: BlockT>(path: &Path, db_type: DatabaseType, create: bool) -> OpenDbResult {
-	match crate::parity_db::open(path, db_type, create, false) {
+fn open_parity_db<Block: BlockT>(path: &Path, db_type: DatabaseType, create: bool, 	recreate_onstart: bool) -> OpenDbResult {
+
+	let mut create_param = create;
+	if recreate_onstart {
+		log::warn!("Deleting all db files and recreating a new ParityDB database on startup.");
+		drop_database(path)?;
+		create_param = true;
+	}
+
+	match crate::parity_db::open(path, db_type, create_param, false) {
 		Ok(db) => Ok(db),
 		Err(parity_db::Error::InvalidConfiguration(_)) => {
 			log::warn!("Invalid parity db configuration, attempting database metadata update.");
@@ -301,6 +319,7 @@ fn open_kvdb_rocksdb<Block: BlockT>(
 	path: &Path,
 	db_type: DatabaseType,
 	create: bool,
+	recreate_onstart: bool,
 	cache_size: usize,
 	limit_size: bool,
 ) -> OpenDbResult {
@@ -340,8 +359,14 @@ fn open_kvdb_rocksdb<Block: BlockT>(
 		},
 	}
 	db_config.memory_budget = memory_budget;
-	if limit_size {
-		db_config.max_total_wal_size = Some(64 * 1024 * 1024);
+	// if limit_size {
+	// 	db_config.max_total_wal_size = Some(64 * 1024 * 1024);
+	// }
+
+	if recreate_onstart {
+		log::warn!("Deleting all db files and recreating a new RocksDB database on startup.");
+		drop_database(path)?;
+		db_config.create_if_missing = true;
 	}
 
 	let db = kvdb_rocksdb::Database::open(&db_config, path)?;
@@ -355,6 +380,7 @@ fn open_kvdb_rocksdb<Block: BlockT>(
 	_path: &Path,
 	_db_type: DatabaseType,
 	_create: bool,
+	_recreate_onstart: bool,
 	_cache_size: usize,
 	_limit_size: bool,
 ) -> OpenDbResult {
@@ -403,7 +429,7 @@ fn maybe_migrate_to_type_subdir<Block: BlockT>(
 			// database stored in the target directory and close the database on success.
 			let mut old_source = source.clone();
 			old_source.set_path(&basedir);
-			open_database_at::<Block>(&old_source, db_type, false, limit_size)?;
+			open_database_at::<Block>(&old_source, db_type, false, false, limit_size)?;
 
 			info!(
 				"Migrating database to a database-type-based subdirectory: '{:?}' -> '{:?}'",
@@ -620,7 +646,7 @@ mod tests {
 			source.set_path(&old_db_path);
 
 			{
-				let db_res = open_database::<Block>(&source, db_type, true);
+				let db_res = open_database::<Block>(&source, db_type, true, false);
 				assert!(db_res.is_ok(), "New database should be created.");
 				assert!(old_db_path.join(db_check_file).exists());
 				assert!(!old_db_path.join(db_type.as_str()).join("db_version").exists());

--- a/substrate/client/db/src/utils.rs
+++ b/substrate/client/db/src/utils.rs
@@ -296,14 +296,13 @@ impl From<io::Error> for OpenDbError {
 
 fn open_parity_db<Block: BlockT>(path: &Path, db_type: DatabaseType, create: bool, 	recreate_onstart: bool) -> OpenDbResult {
 
-	let mut create_param = create;
 	if recreate_onstart {
-		log::warn!("Deleting old db files and recreating a new ParityDB database on startup.");
+		log::info!("Deleting old db files and recreating a new ParityDB database on startup.");
 		drop_database(path)?;
-		create_param = true;
 	}
 
-	match crate::parity_db::open(path, db_type, create_param, false) {
+	let create = create || recreate_onstart;
+	match crate::parity_db::open(path, db_type, create, false) {
 		Ok(db) => Ok(db),
 		Err(parity_db::Error::InvalidConfiguration(_)) => {
 			log::warn!("Invalid parity db configuration, attempting database metadata update.");
@@ -365,7 +364,7 @@ fn open_kvdb_rocksdb<Block: BlockT>(
 	}
 
 	if recreate_onstart {
-		log::warn!("Deleting old db files and recreating a new RocksDB database on startup.");
+		log::info!("Deleting old db files and recreating a new RocksDB database on startup.");
 		drop_database(path)?;
 		db_config.create_if_missing = true;
 	}
@@ -563,7 +562,7 @@ where
 	let block_gap = db
 		.get(COLUMN_META, meta_keys::BLOCK_GAP)
 		.and_then(|d| Decode::decode(&mut d.as_slice()).ok());
-	info!(target: "db", "block_gap={:?}", block_gap);
+	debug!(target: "db", "block_gap={:?}", block_gap);
 
 	Ok(Meta {
 		best_hash,
@@ -647,7 +646,7 @@ mod tests {
 			source.set_path(&old_db_path);
 
 			{
-				let db_res = open_database::<Block>(&source, db_type, true, false);
+				let db_res = open_database::<Block>(&source, db_type, true, false, false);
 				assert!(db_res.is_ok(), "New database should be created.");
 				assert!(old_db_path.join(db_check_file).exists());
 				assert!(!old_db_path.join(db_type.as_str()).join("db_version").exists());
@@ -655,7 +654,7 @@ mod tests {
 
 			source.set_path(&old_db_path.join(db_type.as_str()));
 
-			let db_res = open_database::<Block>(&source, db_type, true);
+			let db_res = open_database::<Block>(&source, db_type, true, false, false);
 			assert!(db_res.is_ok(), "Reopening the db with the same role should work");
 			// check if the database dir had been migrated
 			assert!(!old_db_path.join(db_check_file).exists());
@@ -681,7 +680,7 @@ mod tests {
 
 			let source = DatabaseSource::RocksDb { path: old_db_path.clone(), cache_size: 128 };
 			{
-				let db_res = open_database::<Block>(&source, DatabaseType::Full, true);
+				let db_res = open_database::<Block>(&source, DatabaseType::Full, true, false, false);
 				assert!(db_res.is_ok(), "New database should be created.");
 
 				// check if the database dir had been migrated
@@ -745,13 +744,13 @@ mod tests {
 
 		// it should create new auto (paritydb) database
 		{
-			let db_res = open_database::<Block>(&source, DatabaseType::Full, true);
+			let db_res = open_database::<Block>(&source, DatabaseType::Full, true, false, false);
 			assert!(db_res.is_ok(), "New database should be created.");
 		}
 
 		// it should reopen existing auto (pairtydb) database
 		{
-			let db_res = open_database::<Block>(&source, DatabaseType::Full, true);
+			let db_res = open_database::<Block>(&source, DatabaseType::Full, true, false, false);
 			assert!(db_res.is_ok(), "Existing parity database should be reopened");
 		}
 
@@ -760,7 +759,7 @@ mod tests {
 			let db_res = open_database::<Block>(
 				&DatabaseSource::RocksDb { path: rocksdb_path, cache_size: 128 },
 				DatabaseType::Full,
-				true,
+				true, false, false
 			);
 			assert!(db_res.is_ok(), "New database should be opened.");
 		}
@@ -770,7 +769,7 @@ mod tests {
 			let db_res = open_database::<Block>(
 				&DatabaseSource::ParityDb { path: paritydb_path },
 				DatabaseType::Full,
-				true,
+				true, false, false
 			);
 			assert!(db_res.is_ok(), "Existing parity database should be reopened");
 		}
@@ -788,7 +787,7 @@ mod tests {
 
 		// it should create new rocksdb database
 		{
-			let db_res = open_database::<Block>(&source, DatabaseType::Full, true);
+			let db_res = open_database::<Block>(&source, DatabaseType::Full, true, false, false);
 			assert!(db_res.is_ok(), "New rocksdb database should be created");
 		}
 
@@ -801,7 +800,7 @@ mod tests {
 					cache_size: 128,
 				},
 				DatabaseType::Full,
-				true,
+				true,false, false
 			);
 			assert!(db_res.is_ok(), "Existing rocksdb database should be reopened");
 		}
@@ -811,7 +810,7 @@ mod tests {
 			let db_res = open_database::<Block>(
 				&DatabaseSource::ParityDb { path: paritydb_path },
 				DatabaseType::Full,
-				true,
+				true, false, false
 			);
 			assert!(db_res.is_ok(), "New paritydb database should be created");
 		}
@@ -821,7 +820,7 @@ mod tests {
 			let db_res = open_database::<Block>(
 				&DatabaseSource::RocksDb { path: rocksdb_path, cache_size: 128 },
 				DatabaseType::Full,
-				true,
+				true, false, false
 			);
 			assert!(db_res.is_ok(), "Existing rocksdb database should be reopened");
 		}
@@ -839,13 +838,13 @@ mod tests {
 
 		// it should create new paritydb database
 		{
-			let db_res = open_database::<Block>(&source, DatabaseType::Full, true);
+			let db_res = open_database::<Block>(&source, DatabaseType::Full, true, false, false);
 			assert!(db_res.is_ok(), "New database should be created.");
 		}
 
 		// it should reopen existing pairtydb database
 		{
-			let db_res = open_database::<Block>(&source, DatabaseType::Full, true);
+			let db_res = open_database::<Block>(&source, DatabaseType::Full, true, false, false);
 			assert!(db_res.is_ok(), "Existing parity database should be reopened");
 		}
 
@@ -854,7 +853,7 @@ mod tests {
 			let db_res = open_database::<Block>(
 				&DatabaseSource::RocksDb { path: rocksdb_path.clone(), cache_size: 128 },
 				DatabaseType::Full,
-				true,
+				true, false, false
 			);
 			assert!(db_res.is_ok(), "New rocksdb database should be created");
 		}
@@ -864,7 +863,7 @@ mod tests {
 			let db_res = open_database::<Block>(
 				&DatabaseSource::Auto { paritydb_path, rocksdb_path, cache_size: 128 },
 				DatabaseType::Full,
-				true,
+				true, false, false
 			);
 			assert!(db_res.is_ok(), "Existing parity database should be reopened");
 		}

--- a/substrate/client/network/common/src/sync.rs
+++ b/substrate/client/network/common/src/sync.rs
@@ -34,7 +34,7 @@ pub enum SyncMode {
 	},
 	/// Warp sync - verify authority set transitions and the latest state.
 	Warp,
-	/// minimize startup-time and disk space (BETA, RocksDB only)
+	/// Warp sync but skips gap syncing. Recreates the db on every startup. (BETA)
 	LightRpc,
 }
 

--- a/substrate/client/network/sync/src/strategy/chain_sync.rs
+++ b/substrate/client/network/sync/src/strategy/chain_sync.rs
@@ -242,7 +242,7 @@ pub enum ChainSyncMode {
 		/// Download indexed transactions for recent blocks.
 		storage_chain_mode: bool,
 	},
-	/// minimize startup-time and disk space (BETA, RocksDB only)
+	/// Full mode but skips gap syncing
 	LightRpc,
 }
 
@@ -1385,7 +1385,11 @@ where
 		}
 
 		if let Some((start, end)) = info.block_gap {
-			if self.mode != ChainSyncMode::LightRpc {
+			if self.mode == ChainSyncMode::LightRpc {
+				info!(target: LOG_TARGET, "Skipping gap sync #{start} - #{end}, LightRpc mode" );
+			} else {
+				info!(target: LOG_TARGET, "Starting gap sync #{start} - #{end}");
+
 				debug!(target: LOG_TARGET, "Starting gap sync #{start} - #{end}");
 				self.gap_sync = Some(GapSync {
 					best_queued_number: start - One::one(),

--- a/substrate/client/service/src/builder.rs
+++ b/substrate/client/service/src/builder.rs
@@ -27,7 +27,7 @@ use crate::{
 };
 use futures::{channel::oneshot, future::ready, FutureExt, StreamExt};
 use jsonrpsee::RpcModule;
-use log::info;
+use log::{info, warn};
 use prometheus_endpoint::Registry;
 use sc_chain_spec::get_extension;
 use sc_client_api::{

--- a/substrate/client/service/src/config.rs
+++ b/substrate/client/service/src/config.rs
@@ -258,6 +258,7 @@ impl Configuration {
 			source: self.database.clone(),
 			blocks_pruning: self.blocks_pruning,
 			limit_size: self.network.sync_mode == SyncMode::LightRpc,
+			recreate_onstart: self.network.sync_mode == SyncMode::LightRpc,
 		}
 	}
 }

--- a/substrate/client/service/test/src/lib.rs
+++ b/substrate/client/service/test/src/lib.rs
@@ -233,7 +233,7 @@ fn node_config<E: ChainSpecExtension + Clone + 'static + Send + Sync>(
 		database: DatabaseSource::RocksDb { path: root.join("db"), cache_size: 128 },
 		trie_cache_maximum_size: Some(16 * 1024 * 1024),
 		state_pruning: Default::default(),
-		blocks_pruning: BlocksPruning::KeepFinalized,
+		blocks_pruning: BlocksPruning::KeepFinalized { prune_headers: false },
 		chain_spec: Box::new((*spec).clone()),
 		wasm_method: Default::default(),
 		wasm_runtime_overrides: Default::default(),

--- a/substrate/test-utils/client/src/lib.rs
+++ b/substrate/test-utils/client/src/lib.rs
@@ -102,7 +102,7 @@ impl<Block: BlockT, ExecutorDispatch, G: GenesisInit>
 	/// Create new `TestClientBuilder` with default backend and storage chain mode
 	pub fn with_tx_storage(blocks_pruning: u32) -> Self {
 		let backend =
-			Arc::new(Backend::new_test_with_tx_storage(BlocksPruning::Some(blocks_pruning), 0));
+			Arc::new(Backend::new_test_with_tx_storage(BlocksPruning::Some{blocks: blocks_pruning, prune_headers: false}, 0));
 		Self::with_backend(backend)
 	}
 }


### PR DESCRIPTION
In his PR we:
* Made changes to pruning by also pruning block headers when blocks pruning is enabled. This helped in reducing disk usage.
* Added a mechanism to always clears the db on restarts when Light-rpc mode is on. This was necessary to fix the issue that polkadot-sk disables warp syncing and resorts to full sync if there is some state in the db, undermining the whole point of light-rpc mode. 
* Reduced maximum number of open files for RocksDB
* Added log info message indicating LightRpc mode
